### PR TITLE
Add CLAUDE.md for auto-loading project instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# Claude Code — project instructions
+
+Read and follow `.github/AGENTS.md` before any work. It defines commit style,
+branch naming, PR workflow, and code rules for this repo.
+
+## Quick reference
+
+- Commits: imperative verb in English, no prefixes. `Add`, `Fix`, `Replace`, `Update`, `Remove`.
+- No `Co-Authored-By`. No AI session links.
+- Author: `chuchurex <chuchurex@gmail.com>`.
+- Never commit to `main`. Always branch + PR.
+- One PR per issue. Reference with `Closes #N`.
+- Vanilla JS only. No npm dependencies for the engine.
+
+## Internal docs
+
+Session log and extended workflow notes are in `.internal/WORKFLOW.md` (local only, gitignored).
+Read it at the start of each session for context on past work.


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` to project root — Claude Code reads this automatically at session start
- Contains quick reference of commit/branch/PR rules
- Points to `.github/AGENTS.md` for full rules and `.internal/WORKFLOW.md` for session log